### PR TITLE
Added prefix input and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
           python-version: "3.11"
       - name: 🏗 Install build dependencies
         run: |
-          python -m pip install wheel --user
+          python -m pip install build --user
       - name: 🔨 Build a binary wheel and a source tarball
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: ⬆ Upload build result
         uses: actions/upload-artifact@v4
         with:
@@ -39,10 +39,26 @@ jobs:
           python-version: "3.11"
       - name: 🏗 Set up dev dependencies
         run: |
-          pip install pre-commit
+          pip install -r requirements-dev.txt
       - name: 🚀 Run pre-commit
         run: |
           pre-commit run --all-files --show-diff-on-failure
+
+  test:
+    name: 🧪 Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🏗 Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: 🏗 Set up dev dependencies
+        run: |
+          pip install -r requirements-dev.txt
+      - name: 🚀 Run pytest
+        run: |
+          pytest
 
   publish-on-pypi:
     name: 📦 Publish tagged releases to PyPI
@@ -50,6 +66,7 @@ jobs:
     needs:
       - build
       - pre-commit
+      - test
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/README.md
+++ b/README.md
@@ -55,10 +55,33 @@ plugins:
 Be advised that in case of any customization on your part you need to include the default attributes as well if you want
 to keep them, as the default list will not be included automatically anymore.
 
+If `site:` as the prefix does not work for you for any reason, you can also configure that,
+e.g.
+
+```yaml
+plugins:
+  - site-urls:
+      prefix: "relative:"
+```
+
+This can also be used to interpret absolute URLs like `/example/file.png` as relative,
+by setting the `prefix` to `/`.
+
 ## How it works
 
 The plugin hooks into the [`on_page_content` event](https://www.mkdocs.org/dev-guide/plugins/#on_page_content)
 and replaces all URLs in the configured attributes (by default `href`, `src` or `data`) in the rendered HTML with the corresponding site-relative URLs.
+
+## Development
+
+1. Create a venv & activate it, e.g. `python -m venv venv && source venv/bin/activate`
+2. Install the dev requirements: `pip install -r requirements-dev.txt`
+3. Install the `pre-commit` hooks: `pre-commit install`
+
+You can run the tests with `pytest`.
+
+To build the docs, install their dependencies as well (`pip install -r requirements-docs.txt`),
+then run `mkdocs build`.
 
 ## License
 

--- a/mkdocs_site_urls/__init__.py
+++ b/mkdocs_site_urls/__init__.py
@@ -42,7 +42,7 @@ class SiteUrlsPlugin(mkdocs.plugins.BasePlugin[Config]):
             attribute = match.group(1)
             url = match.group(3)
 
-            logger.info(f"Replacing absolute url '{self.prefix}{url}' with '{path}{url}'")
+            logger.info(f"Replacing '{self.prefix}{url}' with '{path}{url}'")
             return f'{attribute}="{path}{url}"'
 
         return self._regex.sub(_replace, html)

--- a/mkdocs_site_urls/__init__.py
+++ b/mkdocs_site_urls/__init__.py
@@ -18,14 +18,14 @@ class SiteUrlsPlugin(mkdocs.plugins.BasePlugin[Config]):
         attributes = (re.escape(attr) for attr in self.config["attributes"])
         self.prefix = re.escape(self.config["prefix"])
         regex_parts = [
-            r"(", # capturing group 1
-            "|".join(attributes), # attributes
-            r")", # end of capturing group 1
-            r"\s*=\s*", # equals sign with optional whitespace
-            r"([\"'])", # quote with capturing group 2
-            self.prefix, # url prefix
-            r"([^\"']*)", # remainder of the url with capturing group 3
-            r"\2", # matching quote
+            r"(",  # capturing group 1
+            "|".join(attributes),  # attributes
+            r")",  # end of capturing group 1
+            r"\s*=\s*",  # equals sign with optional whitespace
+            r"([\"'])",  # quote with capturing group 2
+            self.prefix,  # url prefix
+            r"([^\"']*)",  # remainder of the url with capturing group 3
+            r"\2",  # matching quote
         ]
         regex = "".join(regex_parts)
         self._regex = re.compile(regex, re.IGNORECASE)
@@ -37,6 +37,7 @@ class SiteUrlsPlugin(mkdocs.plugins.BasePlugin[Config]):
         if not site_url.endswith("/"):
             site_url += "/"
         path = urllib.parse.urlparse(site_url).path
+
         def _replacer(match):
             attribute = match.group(1)
             url = match.group(3)

--- a/mkdocs_site_urls/__init__.py
+++ b/mkdocs_site_urls/__init__.py
@@ -38,11 +38,11 @@ class SiteUrlsPlugin(mkdocs.plugins.BasePlugin[Config]):
             site_url += "/"
         path = urllib.parse.urlparse(site_url).path
 
-        def _replacer(match):
+        def _replace(match):
             attribute = match.group(1)
             url = match.group(3)
 
             logger.info(f"Replacing absolute url '{self.prefix}{url}' with '{path}{url}'")
             return f'{attribute}="{path}{url}"'
 
-        return self._regex.sub(_replacer, html)
+        return self._regex.sub(_replace, html)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pre-commit
+pytest
+-e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+mkdocs>=1.5.0
 pre-commit
 pytest
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 license_file = LICENSE
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 90
 extend-ignore = E203, E231, E265, E266, E402, E501, E731, B023, B903, B904, B907, B950, W503

--- a/tests/test_mkdocs_site_urls.py
+++ b/tests/test_mkdocs_site_urls.py
@@ -2,7 +2,8 @@ import re
 from unittest.mock import MagicMock
 
 import pytest
-from resolve_absolute_urls.plugin import ResolveAbsoluteUrlsPlugin
+
+from mkdocs_site_urls import SiteUrlsPlugin
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def create_plugin(mock_plugin_config):
     """Factory function to create the plugin with the prescribed configuration options."""
 
     def _plugin(config=mock_plugin_config, **kwargs):
-        plugin = ResolveAbsoluteUrlsPlugin()
+        plugin = SiteUrlsPlugin()
         plugin.load_config(config)
         for key, value in kwargs.items():
             setattr(plugin, key, value)
@@ -94,7 +95,7 @@ def test_on_config_sets_regex(
     match_group3,
     should_match,
 ):
-    """Test the on_config method of the ResolveAbsoluteUrlsPlugin."""
+    """Test the on_config method of the SiteUrlsPlugin."""
     plugin_config = {
         "attributes": attributes,
         "prefix": prefix,
@@ -124,7 +125,7 @@ def test_on_config_sets_regex(
     ids=["trailing_slash", "no_trailing_slash"],
 )
 def test_on_page_content(create_plugin, site_url):
-    """Test the on_page_content method of the ResolveAbsoluteUrlsPlugin."""
+    """Test the on_page_content method of the SiteUrlsPlugin."""
     plugin = create_plugin(
         {
             "attributes": ["src", "data"],

--- a/tests/test_mkdocs_site_urls.py
+++ b/tests/test_mkdocs_site_urls.py
@@ -1,9 +1,9 @@
 import re
+from unittest.mock import MagicMock
 
 import pytest
-
-from unittest.mock import MagicMock
 from resolve_absolute_urls.plugin import ResolveAbsoluteUrlsPlugin
+
 
 @pytest.fixture
 def mock_plugin_config():
@@ -114,6 +114,7 @@ def test_on_config_sets_regex(
     else:
         assert match is None
 
+
 @pytest.mark.parametrize(
     "site_url",
     [
@@ -124,27 +125,29 @@ def test_on_config_sets_regex(
 )
 def test_on_page_content(create_plugin, site_url):
     """Test the on_page_content method of the ResolveAbsoluteUrlsPlugin."""
-    plugin = create_plugin({
-        "attributes": ["src", "data"],
-        "prefix": "prefix",
-    })
+    plugin = create_plugin(
+        {
+            "attributes": ["src", "data"],
+            "prefix": "prefix",
+        }
+    )
     page = MagicMock()
     config = MagicMock()
     config.__getitem__.side_effect = lambda key: site_url if key == "site_url" else None
     files = MagicMock()
-    html = '''
+    html = """
     <img src  ="prefixexample.png" alt="Image">
     <img data =  \'prefix/image.png\'>
     <img data="site:docs/image.svg" class="example">
     <img attr  ="prefix/docs/image.png" >
-    '''
+    """
 
     plugin.on_config(config)
     result = plugin.on_page_content(html, page, config, files)
-    expected_result = '''
+    expected_result = """
     <img src="/docs/subpage/example.png" alt="Image">
     <img data="/docs/subpage//image.png">
     <img data="site:docs/image.svg" class="example">
     <img attr  ="prefix/docs/image.png" >
-    '''
+    """
     assert result == expected_result

--- a/tests/test_mkdocs_site_urls.py
+++ b/tests/test_mkdocs_site_urls.py
@@ -1,0 +1,150 @@
+import re
+
+import pytest
+
+from unittest.mock import MagicMock
+from resolve_absolute_urls.plugin import ResolveAbsoluteUrlsPlugin
+
+@pytest.fixture
+def mock_plugin_config():
+    return {"attributes": ["src", "href"], "prefix": "site:"}
+
+
+@pytest.fixture
+def create_plugin(mock_plugin_config):
+    """Factory function to create the plugin with the prescribed configuration options."""
+
+    def _plugin(config=mock_plugin_config, **kwargs):
+        plugin = ResolveAbsoluteUrlsPlugin()
+        plugin.load_config(config)
+        for key, value in kwargs.items():
+            setattr(plugin, key, value)
+        return plugin
+
+    return _plugin
+
+
+@pytest.mark.parametrize(
+    "attributes, prefix, string_to_match, match_group1, match_group3, should_match",
+    [
+        (
+            ["href", "src"],
+            "/docs/",
+            'src = "/docs/image.png"',
+            "src",
+            "image.png",
+            True,
+        ),  # valid1
+        (
+            ["href", "src"],
+            "/",
+            "href ='/docs/image.png'",
+            "href",
+            "docs/image.png",
+            True,
+        ),  # valid2
+        (
+            ["data"],
+            "site:",
+            "data=   'site:image.png'",
+            "data",
+            "image.png",
+            True,
+        ),  # valid3
+        (
+            ["href", "src"],
+            "/docs/",
+            'src = "/image.png"',
+            None,
+            None,
+            False,
+        ),  # invalid_different_prefix
+        (
+            ["href", "src"],
+            "/",
+            "href ='site:docs/image.png'",
+            None,
+            None,
+            False,
+        ),  # invalid_different_prefix2
+        (
+            ["data"],
+            "/",
+            "href='/image.png'",
+            None,
+            None,
+            False,
+        ),  # invalid_different_attribute
+    ],
+    ids=[
+        "valid1",
+        "valid2",
+        "valid3",
+        "invalid_different_prefix",
+        "invalid_different_prefix2",
+        "invalid_different_attribute",
+    ],
+)
+def test_on_config_sets_regex(
+    create_plugin,
+    attributes,
+    prefix,
+    string_to_match,
+    match_group1,
+    match_group3,
+    should_match,
+):
+    """Test the on_config method of the ResolveAbsoluteUrlsPlugin."""
+    plugin_config = {
+        "attributes": attributes,
+        "prefix": prefix,
+    }
+    plugin = create_plugin(plugin_config)
+    plugin.on_config(MagicMock())
+
+    # Check that the regex is compiled
+    assert isinstance(plugin._regex, re.Pattern)
+    match = plugin._regex.search(string_to_match)
+
+    # Check regex is correct
+    if should_match:
+        assert match is not None
+        assert match.group(1) == match_group1
+        assert match.group(3) == match_group3
+    else:
+        assert match is None
+
+@pytest.mark.parametrize(
+    "site_url",
+    [
+        "https://example.com/docs/subpage/",
+        "https://example.com/docs/subpage",
+    ],
+    ids=["trailing_slash", "no_trailing_slash"],
+)
+def test_on_page_content(create_plugin, site_url):
+    """Test the on_page_content method of the ResolveAbsoluteUrlsPlugin."""
+    plugin = create_plugin({
+        "attributes": ["src", "data"],
+        "prefix": "prefix",
+    })
+    page = MagicMock()
+    config = MagicMock()
+    config.__getitem__.side_effect = lambda key: site_url if key == "site_url" else None
+    files = MagicMock()
+    html = '''
+    <img src  ="prefixexample.png" alt="Image">
+    <img data =  \'prefix/image.png\'>
+    <img data="site:docs/image.svg" class="example">
+    <img attr  ="prefix/docs/image.png" >
+    '''
+
+    plugin.on_config(config)
+    result = plugin.on_page_content(html, page, config, files)
+    expected_result = '''
+    <img src="/docs/subpage/example.png" alt="Image">
+    <img data="/docs/subpage//image.png">
+    <img data="site:docs/image.svg" class="example">
+    <img attr  ="prefix/docs/image.png" >
+    '''
+    assert result == expected_result


### PR DESCRIPTION
Fixes #3. 

### PR Overview
- [x] A `prefix` input parameter was added, allowing the absolute link prefix to be easily controlled by the user. Default value has been set to current version's prefix `site:`.
- [x] The `prefix` is escaped (using `re.escape`) to avoid potentially treating the prefix characters as regex special characters.
- [x] A very simple unit testing suite was added, to increase the robustness of the plugin
- [x] Few improvements in some portions of the plugin, without modifying functionality. 

### Integration tests
I didn't peform any integration test as I don't have quick ways to check that the outputs of the current version of the plugin (witihout this PR) are the same of the ones with this PR included (with default input parameters).
Please feel free to perform these tests, and if there are any issues I'm happy to work on them. 

Cheers
Davide
